### PR TITLE
Fix vibration cycle count

### DIFF
--- a/Watch/Application/Vibration.c
+++ b/Watch/Application/Vibration.c
@@ -141,11 +141,11 @@ void VibrationMotorStateMachineIsr(void)
         motorOn = pdFALSE;
         nextActionTime +=  timeOff;
         
-        if ( cycleCount > 0 )
+        if ( cycleCount > 1 )
         {
           cycleCount -= 1;
         }
-        else /* the count is zero */
+        else /* last cycle */
         {
           VibeEventActive = pdFALSE;
           DisableRtcPrescaleInterruptUser(RTC_TIMER_VIBRATION);


### PR DESCRIPTION
In firmware 0.8.X, a cycle count of 1 would mean 1 vibration. With the current implementation on 0.10.X, a cycle count of 1 results in 2 vibrations. This causes confusion for both users and developers and is not really backwards compatible.

This commit changes the behavior to the old, expected one, with a very minor change.
