### PR TITLE
Fix erroneous display in 24 hour mode.

### DIFF
--- a/Watch/Application/LcdDisplay.c
+++ b/Watch/Application/LcdDisplay.c
@@ -1782,8 +1782,8 @@ static void DisplayAmPm(void)
 
 static void DisplayDayOfWeek(void)
 {
-  /* row offset = 10 , column offset = 8 */
-  WriteIcon4w10h(DaysOfWeek[RTCDOW],10,8);
+  /* row offset = 0 or 10 , column offset = 8 */
+  WriteIcon4w10h(DaysOfWeek[RTCDOW], GetTimeFormat() == TWENTY_FOUR_HOUR ? 0 : 10, 8);
 }
 
 static void DisplayDate(void)


### PR DESCRIPTION
The "Show year in 24h mode" pull request (#14) was broken in commit 2caea83ff3be63adc96935baeeb2f5a64183e5eb, causing the day of week and date to be printed on the same row.

This commit fixes the bug using code from commit 70ea9139285e73e2431b1c58644d1e34d803fe8a.
